### PR TITLE
Modernize Tkinter UI with responsive dashboard and unified dark theme

### DIFF
--- a/exfat_builder.py
+++ b/exfat_builder.py
@@ -700,7 +700,7 @@ if not is_admin():
 # Step 3+ will migrate widgets to either ttk styles or direct COLORS[...] /
 # FONTS[...] lookups; for now the indirection lets us flip the entire palette
 # in one place.
-from tkinter_theme import apply_theme, COLORS, FONTS
+from tkinter_theme import apply_theme, COLORS, FONTS, SPACING
 
 BG           = COLORS['bg_1']        # was '#000000' — design system uses #0a0a0a (near-black, never pure)
 SURFACE2     = COLORS['bg_4']        # was '#1c1c1c' — closest design token is #1a1a1a
@@ -3618,21 +3618,54 @@ class ExFATBuilder(_TK_BASE):
 
     def _build_ui(self):
         # ── Header ──
-        hdr = tk.Frame(self, bg=BG)
-        hdr.pack(fill='x', padx=24, pady=(10, 6))
-        title_row = tk.Frame(hdr, bg=BG)
+        hdr = tk.Frame(self, bg=COLORS['bg_2'])
+        hdr.pack(fill='x')
+        header_inner = tk.Frame(hdr, bg=COLORS['bg_2'])
+        header_inner.pack(
+            fill='x', padx=SPACING['xxl'], pady=(SPACING['lg'], SPACING['md']))
+        title_row = tk.Frame(header_inner, bg=COLORS['bg_2'])
         title_row.pack(fill='x')
-        tk.Label(title_row, text='exFAT Image Builder',
-                 font=('Segoe UI', 16, 'bold'), bg=BG, fg=TEXT).pack(side='left', anchor='w')
-        tk.Label(title_row, text='v' + APP_VERSION,
-                 font=('Segoe UI', 8), bg=BG, fg='#3a3a3a').pack(side='left', anchor='s', padx=(8,0), pady=(0,4))
-        tk.Label(title_row, text='by DecKerr97',
-                 font=('Segoe UI', 9), bg=BG, fg='#555555').pack(side='right', anchor='s', pady=(6, 0))
-        tk.Label(hdr, text='Build PS5 exFAT game images  \u2014  scripts bundled, game name auto-detected',
-                 font=('Segoe UI', 10), bg=BG, fg=MUTED).pack(anchor='w')
-        tk.Label(hdr, text='Inspired by NookieAI \u2022 stonemodder (Porkfolio)',
-                 font=('Segoe UI', 8), bg=BG, fg='#3a3a3a').pack(anchor='w')
-        tk.Frame(self, bg=BORDER, height=1).pack(fill='x')
+        brand_tile = tk.Label(
+            title_row, text='EX', font=(FONTS['body'][0], 11, 'bold'),
+            bg=COLORS['accent'], fg=COLORS['fg_0'],
+            width=3, height=2,
+            highlightbackground=COLORS['accent_hi'],
+            highlightthickness=1)
+        brand_tile.pack(side='left', padx=(0, SPACING['md']))
+        brand_copy = tk.Frame(title_row, bg=COLORS['bg_2'])
+        brand_copy.pack(side='left', fill='x', expand=True)
+        brand_name_row = tk.Frame(brand_copy, bg=COLORS['bg_2'])
+        brand_name_row.pack(fill='x')
+        tk.Label(brand_name_row, text='exFAT Image Builder',
+                 font=FONTS['h2'], bg=COLORS['bg_2'],
+                 fg=COLORS['fg_0']).pack(side='left', anchor='w')
+        version_badge = tk.Label(
+            brand_name_row, text=' v' + APP_VERSION + ' ',
+            font=FONTS['eyebrow'], bg=COLORS['accent_08'],
+            fg=COLORS['accent_hi'], padx=SPACING['xs'], pady=SPACING['xxs'])
+        version_badge.pack(
+            side='left', anchor='s', padx=(SPACING['sm'], 0),
+            pady=(0, SPACING['xxs']))
+        tk.Label(
+            brand_copy,
+            text=('Build PS5 exFAT game images  \u2014  scripts bundled, '
+                  'game name auto-detected'),
+            font=FONTS['meta'], bg=COLORS['bg_2'], fg=COLORS['fg_3']
+        ).pack(anchor='w', pady=(SPACING['xxs'], 0))
+        attribution = tk.Frame(
+            title_row, bg=COLORS['bg_3'],
+            highlightbackground=COLORS['border_3'], highlightthickness=1)
+        attribution.pack(side='right', padx=(SPACING['lg'], 0))
+        tk.Label(attribution, text='by DecKerr97',
+                 font=FONTS['label'], bg=COLORS['bg_3'],
+                 fg=COLORS['fg_2']).pack(
+                     anchor='e', padx=SPACING['md'], pady=(7, 0))
+        tk.Label(attribution,
+                 text='Inspired by NookieAI \u2022 stonemodder',
+                 font=FONTS['meta'], bg=COLORS['bg_3'],
+                 fg=COLORS['fg_5']).pack(
+                     anchor='e', padx=SPACING['md'], pady=(0, 7))
+        tk.Frame(self, bg=COLORS['border_3'], height=1).pack(fill='x')
 
         # ── Navigation ──
         # v4.0 Entry 2 Phase 3: the legacy top tab bar has been REMOVED. The
@@ -3647,15 +3680,16 @@ class ExFATBuilder(_TK_BASE):
         self._tab_extract_frame = None
 
         # ── Global output log (visible across all tabs) ──
-        self._ps5_status_frame = tk.Frame(self, bg='#0d0d0d')
+        self._ps5_status_frame = tk.Frame(self, bg=COLORS['bg_0'])
         self._ps5_status_frame.pack(side='bottom', fill='x')
         self._build_ps5_status_bar(self._ps5_status_frame)
 
-        self._global_log_frame = tk.Frame(self, bg=BG)
+        self._global_log_frame = tk.Frame(self, bg=COLORS['bg_0'])
         self._global_log_frame.pack(side='bottom', fill='x', padx=0, pady=0)
         self._build_global_log(self._global_log_frame)
 
-        tk.Frame(self, bg=BORDER, height=1).pack(side='bottom', fill='x')
+        tk.Frame(self, bg=COLORS['border_3'], height=1).pack(
+            side='bottom', fill='x')
 
         # ── Stage 3 (UI refactor): secondary sidebar navigation ─────────
         # ADDITIVE — the top tab strip above is unchanged and remains the
@@ -3668,7 +3702,7 @@ class ExFATBuilder(_TK_BASE):
         self._sidebar = None
         try:
             from ui.shared.sidebar import Sidebar as _Sidebar
-            sidebar = _Sidebar(self, width=210, rail_width=60)
+            sidebar = _Sidebar(self, width=224, rail_width=64)
             sidebar.pack(side='left', fill='y')
             # Route sidebar clicks through the existing _switch_tab.
             sidebar.on_select = self._switch_tab
@@ -3681,7 +3715,8 @@ class ExFATBuilder(_TK_BASE):
                     pass
             sidebar.on_toggle = _persist_sidebar_collapsed
             # Thin divider between sidebar and content.
-            tk.Frame(self, bg=BORDER, width=1).pack(side='left', fill='y')
+            tk.Frame(self, bg=COLORS['border_3'], width=1).pack(
+                side='left', fill='y')
 
             # WORKSPACE — quick link to the default landing tab.
             # NOTE: there is no separate Dashboard tab in Stage 3 — this
@@ -3735,12 +3770,23 @@ class ExFATBuilder(_TK_BASE):
             # SYSTEM STATUS — pinned footer (real text only, no controls).
             footer = sidebar.footer()
             self._sidebar_status_lbl = tk.Label(
-                footer, text=_('SYSTEM STATUS'), bg=BG, fg='#5d5775',
-                font=('Segoe UI', 8, 'bold'), anchor='w')
-            self._sidebar_status_lbl.pack(fill='x', padx=12, pady=(8, 2))
-            tk.Label(footer, text='exFAT Image Builder v' + APP_VERSION,
-                     bg=BG, fg=MUTED, font=('Segoe UI', 8),
-                     anchor='w').pack(fill='x', padx=12, pady=(0, 10))
+                footer, text=_('SYSTEM STATUS'), bg=COLORS['bg_0'],
+                fg=COLORS['fg_5'], font=FONTS['eyebrow'], anchor='w')
+            self._sidebar_status_lbl.pack(
+                fill='x', padx=14, pady=(10, 5))
+            status_row = tk.Frame(
+                footer, bg=COLORS['bg_2'],
+                highlightbackground=COLORS['border_3'],
+                highlightthickness=1)
+            status_row.pack(fill='x', padx=10, pady=(0, 12))
+            tk.Label(status_row, text='\u25cf', bg=COLORS['bg_2'],
+                     fg=COLORS['success'],
+                     font=(FONTS['body'][0], 8)).pack(
+                         side='left', padx=(10, 7), pady=8)
+            tk.Label(status_row, text='Ready  \u00b7  v' + APP_VERSION,
+                     bg=COLORS['bg_2'], fg=COLORS['fg_3'],
+                     font=FONTS['meta'], anchor='w').pack(
+                         side='left', pady=8)
 
             self._sidebar = sidebar
             # Phase 5A: restore the saved collapse state (no re-persist).
@@ -22486,29 +22532,31 @@ class ExFATBuilder(_TK_BASE):
 
     def _build_ps5_status_bar(self, parent):
         """Persistent PS5 connection + queue status bar."""
-        bar = tk.Frame(parent, bg='#0d0d0d',
-                       highlightbackground=BORDER, highlightthickness=1)
+        bar_bg = COLORS['bg_0']
+        bar = tk.Frame(parent, bg=bar_bg,
+                       highlightbackground=COLORS['border_3'],
+                       highlightthickness=1)
         bar.pack(fill='x')
         self._ps5_status_var = tk.StringVar(value='PS5  ●  Not connected')
         self._ps5_status_lbl = tk.Label(
             bar, textvariable=self._ps5_status_var,
-            font=('Segoe UI', 8), bg='#0d0d0d', fg='#444444',
-            padx=10, pady=3, cursor='hand2')
+            font=FONTS['meta'], bg=bar_bg, fg=COLORS['fg_5'],
+            padx=14, pady=7, cursor='hand2')
         self._ps5_status_lbl.pack(side='left')
         self._ps5_status_lbl.bind('<Button-1>', lambda e: self._ps5_status_ping())
 
         tk.Label(bar, text='│', font=('Segoe UI', 8),
-                 bg='#0d0d0d', fg=BORDER).pack(side='left')
+                 bg=bar_bg, fg=COLORS['border_4']).pack(side='left')
 
         self._ftp_status_var = tk.StringVar(value='FTP  ●  Idle')
         tk.Label(bar, textvariable=self._ftp_status_var,
-                 font=('Segoe UI', 8), bg='#0d0d0d', fg='#444444',
-                 padx=10, pady=3).pack(side='left')
+                 font=FONTS['meta'], bg=bar_bg, fg=COLORS['fg_5'],
+                 padx=14, pady=7).pack(side='left')
 
         self._queue_status_var = tk.StringVar(value='')
         tk.Label(bar, textvariable=self._queue_status_var,
-                 font=('Segoe UI', 8), bg='#0d0d0d', fg='#58a6ff',
-                 padx=10, pady=3).pack(side='right')
+                 font=FONTS['meta'], bg=bar_bg, fg=COLORS['accent_hi'],
+                 padx=14, pady=7).pack(side='right')
 
         self.after(5000, self._ps5_status_ping_loop)
 
@@ -22516,7 +22564,7 @@ class ExFATBuilder(_TK_BASE):
         ip = self._settings.get('ps5_ip', self._settings.get('ftp_ip', '')).strip()
         if not ip:
             self._ps5_status_var.set('PS5  ●  No IP set — click to ping')
-            self._ps5_status_lbl.config(fg='#444444')
+            self._ps5_status_lbl.config(fg=COLORS['fg_5'])
             return
         import threading, socket
         def _ping():
@@ -22534,7 +22582,8 @@ class ExFATBuilder(_TK_BASE):
                 self.after(0, self._ps5_status_lbl.config, {'fg': SUCCESS})
             else:
                 self.after(0, self._ps5_status_var.set, '🎮 PS5  ●  Offline  (%s)' % ip)
-                self.after(0, self._ps5_status_lbl.config, {'fg': '#444444'})
+                self.after(0, self._ps5_status_lbl.config,
+                           {'fg': COLORS['fg_5']})
         threading.Thread(target=_ping, daemon=True).start()
 
     def _ps5_status_ping_loop(self):
@@ -22546,53 +22595,57 @@ class ExFATBuilder(_TK_BASE):
         self._log_visible = tk.BooleanVar(value=False)
 
         # Header row — click to expand/collapse
-        log_header = tk.Frame(parent, bg=SURFACE2,
-                              highlightbackground=BORDER, highlightthickness=1)
+        log_header = tk.Frame(parent, bg=COLORS['bg_2'],
+                              highlightbackground=COLORS['border_3'],
+                              highlightthickness=1)
         log_header.pack(fill='x')
 
         self._log_toggle_lbl = tk.Label(
             log_header,
             text='\u25b6  OUTPUT LOG',
-            font=('Segoe UI', 8, 'bold'),
-            bg=SURFACE2, fg=MUTED,
-            cursor='hand2', padx=10, pady=4)
+            font=FONTS['eyebrow'],
+            bg=COLORS['bg_2'], fg=COLORS['fg_3'],
+            cursor='hand2', padx=14, pady=8)
         self._log_toggle_lbl.pack(side='left')
         self._log_toggle_lbl.bind('<Button-1>', lambda e: self._toggle_log())
 
         tk.Button(log_header, text='Clear',
-                  font=('Segoe UI', 8),
-                  bg=SURFACE2, fg=MUTED,
-                  activebackground=SURFACE2, relief='flat', bd=0,
-                  padx=8, pady=3, cursor='hand2',
+                  font=FONTS['meta'],
+                  bg=COLORS['bg_2'], fg=COLORS['fg_3'],
+                  activebackground=COLORS['bg_3'], relief='flat', bd=0,
+                  padx=10, pady=6, cursor='hand2',
                   command=self._log_clear).pack(side='right', padx=(0, 4))
 
         # v3.6.3: Copy the whole Output Log to the clipboard. Does not modify
         # or clear the log. A small status label briefly confirms the copy.
         self._log_copy_status = tk.Label(
-            log_header, text='', font=('Segoe UI', 8),
-            bg=SURFACE2, fg=MUTED)
+            log_header, text='', font=FONTS['meta'],
+            bg=COLORS['bg_2'], fg=COLORS['fg_3'])
         self._log_copy_status.pack(side='right', padx=(0, 6))
         tk.Button(log_header, text='Copy',
-                  font=('Segoe UI', 8),
-                  bg=SURFACE2, fg=MUTED,
-                  activebackground=SURFACE2, relief='flat', bd=0,
-                  padx=8, pady=3, cursor='hand2',
+                  font=FONTS['meta'],
+                  bg=COLORS['bg_2'], fg=COLORS['fg_3'],
+                  activebackground=COLORS['bg_3'], relief='flat', bd=0,
+                  padx=10, pady=6, cursor='hand2',
                   command=self._log_copy).pack(side='right', padx=(0, 4))
 
         # Log body (hidden by default)
-        self._log_body = tk.Frame(parent, bg=BG)
-        log_outer = tk.Frame(self._log_body, bg=BG,
-                             highlightbackground=BORDER, highlightthickness=1)
+        self._log_body = tk.Frame(parent, bg=COLORS['bg_0'])
+        log_outer = tk.Frame(self._log_body, bg=COLORS['bg_0'],
+                             highlightbackground=COLORS['border_4'],
+                             highlightthickness=1)
         log_outer.pack(fill='x', padx=0, pady=(2, 0))
-        log_sb = tk.Scrollbar(log_outer, bg=BG, troughcolor=SURFACE2)
+        log_sb = tk.Scrollbar(
+            log_outer, bg=COLORS['bg_2'], troughcolor=COLORS['bg_0'])
         log_sb.pack(side='right', fill='y')
         self.log_box = tk.Text(
             log_outer,
             height=8,
-            font=('Consolas', 8),
-            bg='#0a0a0f', fg='#a0c8a0',
-            insertbackground='#a0c8a0',
-            relief='flat', bd=6,
+            font=FONTS['mono_sm'],
+            bg=COLORS['bg_0'], fg=COLORS['success_hi'],
+            insertbackground=COLORS['success_hi'],
+            selectbackground=COLORS['success_bg'],
+            relief='flat', bd=10,
             state='disabled', wrap='word',
             yscrollcommand=log_sb.set)
         self.log_box.pack(fill='x')

--- a/tkinter_theme.py
+++ b/tkinter_theme.py
@@ -55,81 +55,81 @@ import platform
 COLORS = {
     # Backgrounds — purple-tinted dark per v1-bundle/backports-tab.html
     # (deepest is bg_0 = #0a0812; panels lighten through bg_5)
-    "bg_0":     "#0a0812",
-    "bg_1":     "#110d1c",
-    "bg_2":     "#16121f",
-    "bg_3":     "#1d1729",
-    "bg_4":     "#251e34",
-    "bg_5":     "#2d2540",
+    "bg_0":     "#090b0f",
+    "bg_1":     "#0e1116",
+    "bg_2":     "#151920",
+    "bg_3":     "#1b212a",
+    "bg_4":     "#232b36",
+    "bg_5":     "#2d3744",
 
     # Borders — slight purple tint
-    "border_1": "#1c1729",
-    "border_2": "#25203a",
-    "border_3": "#322a47",
-    "border_4": "#3a3252",
+    "border_1": "#171c23",
+    "border_2": "#242c36",
+    "border_3": "#35414f",
+    "border_4": "#465568",
 
     # Foregrounds — warm-leaning grays for contrast against purple-bg
-    "fg_0":     "#f3f0fa",   # heading
-    "fg_1":     "#e0dcec",
-    "fg_2":     "#c5c0d2",
-    "fg_3":     "#9d97ad",
-    "fg_4":     "#7a7390",
-    "fg_5":     "#5d5775",
-    "fg_6":     "#423d57",
+    "fg_0":     "#f5f7fa",
+    "fg_1":     "#e3e8ef",
+    "fg_2":     "#c8d0da",
+    "fg_3":     "#a7b1bf",
+    "fg_4":     "#8f9aa8",
+    "fg_5":     "#75808e",
+    "fg_6":     "#4e5967",
 
     # Dark fields (Step 35 / v2.2.16): the app's text inputs are now
     # dark — matches the rest of the theme and prevents white-bg
     # entries from screaming against the dark UI. The previous light
     # fields (field_bg=#f0eef5, field_fg=#000000) were a deliberate
     # Windows-form-style choice; user feedback rejected that.
-    "field_bg": "#251e34",
-    "field_fg": "#e0dcec",
-    "field_select_bg": "#b07ad6",
+    "field_bg": "#11161d",
+    "field_fg": "#e3e8ef",
+    "field_select_bg": "#6ea8fe",
     "field_select_fg": "#ffffff",
 
     # Accent — purple is now the global accent (was electric blue).
     # The CSS mock used `--purple` as the primary action color.
-    "accent":     "#b07ad6",
-    "accent_hi":  "#c993e8",
-    "accent_lo":  "#2a1a3d",
-    "accent_08":  "#1a0d2a",   # opaque equivalent of purple @ 8% over bg_1
-    "accent_15":  "#241540",
-    "accent_pressed": "#8e60b8",
+    "accent":     "#6ea8fe",
+    "accent_hi":  "#9ac4ff",
+    "accent_lo":  "#1b3554",
+    "accent_08":  "#111d2c",
+    "accent_15":  "#182a40",
+    "accent_pressed": "#4f86d9",
 
     # Status — adjusted for the purple-tint background
     # (greens/ambers/reds shifted slightly cooler so they harmonize)
-    "success":    "#4ec9a4",
-    "success_hi": "#6fdcb8",
-    "success_bg": "#0f2418",
+    "success":    "#45c7a5",
+    "success_hi": "#72ddc0",
+    "success_bg": "#102720",
     "success_ok": "#00ff41",   # terminal phosphor green — klog only;
                                 # intentionally retina-burning since
                                 # klog is meant to evoke a CRT terminal
 
-    "warn":       "#d6a85a",
-    "warn_hi":    "#e8c074",
-    "warn_bg":    "#241a08",
+    "warn":       "#e1ad56",
+    "warn_hi":    "#f0c875",
+    "warn_bg":    "#2b210f",
 
-    "danger":     "#d65a6a",
-    "danger_hi":  "#e87a8a",
-    "danger_bg":  "#240e14",
+    "danger":     "#df6676",
+    "danger_hi":  "#ef8b98",
+    "danger_bg":  "#2b141a",
 
-    "info_bg":    "#1a0d2a",
+    "info_bg":    "#111d2c",
 
     # Confidence dots (Dump Rename)
-    "conf_clean": "#4ec9a4",
-    "conf_guess": "#d6a85a",
-    "conf_fail":  "#d65a6a",
+    "conf_clean": "#45c7a5",
+    "conf_guess": "#e1ad56",
+    "conf_fail":  "#df6676",
 
     # Purple — same as accent now (kept as separate tokens for clarity
     # when code semantically wants "this means backport" vs "this means
     # primary action")
-    "purple":     "#b07ad6",
-    "purple_hi":  "#c993e8",
+    "purple":     "#b58cff",
+    "purple_hi":  "#c9adff",
     # Teal — kept distinct for ffpkg, shifted to harmonize with purple
-    "teal":       "#5ac9b8",
-    "teal_hi":    "#7adcca",
-    "teal_bg":    "#0e221f",
-    "teal_lo":    "#1f4a42",
+    "teal":       "#50c5c7",
+    "teal_hi":    "#7ddbdd",
+    "teal_bg":    "#102526",
+    "teal_lo":    "#204b4d",
 }
 
 # ────────────────────────────────────────────────────────────────────
@@ -178,8 +178,8 @@ _SANS = _SANS_FALLBACK
 _MONO = _MONO_FALLBACK
 
 FONTS = {
-    "h1":      (_SANS, 22, "bold"),
-    "h2":      (_SANS, 15, "bold"),
+    "h1":      (_SANS, 24, "bold"),
+    "h2":      (_SANS, 16, "bold"),
     "h3":      (_SANS, 12, "bold"),
     "eyebrow": (_SANS,  9, "bold"),    # render uppercase manually
     "body":    (_SANS, 10, "normal"),
@@ -287,8 +287,10 @@ def apply_theme(root: tk.Tk) -> ttk.Style:
     # ── TFrame ──
     style.configure("TFrame",         background=C["bg_1"])
     style.configure("Surface.TFrame", background=C["bg_1"])
-    style.configure("Card.TFrame",    background=C["bg_2"], relief="flat", borderwidth=1)
-    style.configure("Panel.TFrame",   background=C["bg_3"], relief="flat", borderwidth=1)
+    style.configure("Card.TFrame", background=C["bg_2"], relief="solid",
+                    borderwidth=1, bordercolor=C["border_3"])
+    style.configure("Panel.TFrame", background=C["bg_3"], relief="solid",
+                    borderwidth=1, bordercolor=C["border_3"])
 
     # ── TLabelframe (sectioned cards) ──
     style.configure("TLabelframe",
@@ -333,7 +335,8 @@ def apply_theme(root: tk.Tk) -> ttk.Style:
                     lightcolor=C["border_3"],
                     darkcolor=C["border_3"],
                     relief="flat",
-                    padding=(14, 7),
+                    padding=(16, 9),
+                    focuscolor=C["accent"],
                     font=F["button"])
     style.map("TButton",
               background=[("active", C["bg_5"]),
@@ -346,55 +349,81 @@ def apply_theme(root: tk.Tk) -> ttk.Style:
     style.configure("Primary.TButton",
                     background=C["accent"], foreground=C["fg_0"],
                     bordercolor=C["accent"], lightcolor=C["accent"], darkcolor=C["accent"],
-                    padding=(16, 8), font=F["button"], relief="flat")
+                    padding=(18, 10), font=F["body_b"], relief="flat",
+                    focuscolor=C["fg_0"])
     style.map("Primary.TButton",
               background=[("active", C["accent_hi"]),
                           ("pressed", C["accent_pressed"]),
                           ("disabled", C["bg_3"])],
-              foreground=[("disabled", C["fg_6"])])
+              foreground=[("disabled", C["fg_6"])],
+              bordercolor=[("focus", C["fg_0"])],
+              lightcolor=[("focus", C["fg_0"])],
+              darkcolor=[("focus", C["fg_0"])])
 
     style.configure("Secondary.TButton",
                     background=C["bg_4"], foreground=C["accent"],
                     bordercolor=C["accent"], lightcolor=C["accent"], darkcolor=C["accent"],
-                    padding=(14, 7), relief="flat")
+                    padding=(16, 9), relief="flat", focuscolor=C["accent_hi"])
     style.map("Secondary.TButton",
-              background=[("active", C["accent_08"]), ("pressed", C["accent_15"])])
+              background=[("active", C["accent_08"]), ("pressed", C["accent_15"])],
+              bordercolor=[("focus", C["accent_hi"])],
+              lightcolor=[("focus", C["accent_hi"])],
+              darkcolor=[("focus", C["accent_hi"])])
 
     style.configure("Ghost.TButton",
                     background=C["bg_1"], foreground=C["fg_3"],
                     bordercolor=C["bg_1"], lightcolor=C["bg_1"], darkcolor=C["bg_1"],
-                    padding=(10, 6), relief="flat")
+                    padding=(13, 8), relief="flat", focuscolor=C["accent"])
     style.map("Ghost.TButton",
               background=[("active", C["bg_3"]), ("pressed", C["bg_4"])],
-              foreground=[("active", C["fg_1"])])
+              foreground=[("active", C["fg_1"])],
+              bordercolor=[("focus", C["accent"])],
+              lightcolor=[("focus", C["accent"])],
+              darkcolor=[("focus", C["accent"])])
 
     style.configure("Warn.TButton",
                     background=C["warn"], foreground="#1a0e00",
                     bordercolor=C["warn"], lightcolor=C["warn"], darkcolor=C["warn"],
-                    padding=(14, 7), font=F["body_b"], relief="flat")
+                    padding=(16, 9), font=F["body_b"], relief="flat",
+                    focuscolor=C["fg_0"])
     style.map("Warn.TButton",
-              background=[("active", C["warn_hi"]), ("pressed", "#cc8800")])
+              background=[("active", C["warn_hi"]), ("pressed", "#cc8800")],
+              bordercolor=[("focus", C["fg_0"])],
+              lightcolor=[("focus", C["fg_0"])],
+              darkcolor=[("focus", C["fg_0"])])
 
     style.configure("Danger.TButton",
                     background=C["danger"], foreground=C["fg_0"],
                     bordercolor=C["danger"], lightcolor=C["danger"], darkcolor=C["danger"],
-                    padding=(14, 7), font=F["body_b"], relief="flat")
+                    padding=(16, 9), font=F["body_b"], relief="flat",
+                    focuscolor=C["fg_0"])
     style.map("Danger.TButton",
-              background=[("active", C["danger_hi"]), ("pressed", "#c62828")])
+              background=[("active", C["danger_hi"]), ("pressed", "#c62828")],
+              bordercolor=[("focus", C["fg_0"])],
+              lightcolor=[("focus", C["fg_0"])],
+              darkcolor=[("focus", C["fg_0"])])
 
     style.configure("Success.TButton",
                     background=C["success"], foreground=C["fg_0"],
                     bordercolor=C["success"], lightcolor=C["success"], darkcolor=C["success"],
-                    padding=(14, 7), font=F["body_b"], relief="flat")
+                    padding=(16, 9), font=F["body_b"], relief="flat",
+                    focuscolor=C["fg_0"])
     style.map("Success.TButton",
-              background=[("active", C["success_hi"]), ("pressed", "#388e3c")])
+              background=[("active", C["success_hi"]), ("pressed", "#388e3c")],
+              bordercolor=[("focus", C["fg_0"])],
+              lightcolor=[("focus", C["fg_0"])],
+              darkcolor=[("focus", C["fg_0"])])
 
     style.configure("Backport.TButton",
                     background=C["purple"], foreground=C["fg_0"],
                     bordercolor=C["purple"], lightcolor=C["purple"], darkcolor=C["purple"],
-                    padding=(14, 7), font=F["body_b"], relief="flat")
+                    padding=(16, 9), font=F["body_b"], relief="flat",
+                    focuscolor=C["fg_0"])
     style.map("Backport.TButton",
-              background=[("active", C["purple_hi"]), ("pressed", "#7d3c98")])
+              background=[("active", C["purple_hi"]), ("pressed", "#7d3c98")],
+              bordercolor=[("focus", C["fg_0"])],
+              lightcolor=[("focus", C["fg_0"])],
+              darkcolor=[("focus", C["fg_0"])])
 
     # ── TCheckbutton / TRadiobutton ──
     style.configure("TCheckbutton",
@@ -424,7 +453,7 @@ def apply_theme(root: tk.Tk) -> ttk.Style:
     style.configure("TEntry",
                     fieldbackground=C["field_bg"], foreground=C["field_fg"],
                     bordercolor=C["border_3"], lightcolor=C["border_3"], darkcolor=C["border_3"],
-                    insertcolor=C["accent"], padding=6, relief="flat")
+                    insertcolor=C["accent"], padding=9, relief="flat")
     style.map("TEntry",
               bordercolor=[("focus", C["accent"])],
               lightcolor=[("focus", C["accent"])],
@@ -440,7 +469,7 @@ def apply_theme(root: tk.Tk) -> ttk.Style:
     style.configure("TCombobox",
                     fieldbackground=C["field_bg"], foreground=C["field_fg"],
                     background=C["bg_4"], arrowcolor=C["fg_2"],
-                    bordercolor=C["border_3"], padding=6, relief="flat")
+                    bordercolor=C["border_3"], padding=9, relief="flat")
     style.map("TCombobox",
               fieldbackground=[("readonly", C["bg_4"])],
               foreground=[("readonly", C["fg_1"])],
@@ -493,14 +522,14 @@ def apply_theme(root: tk.Tk) -> ttk.Style:
     style.configure("Treeview",
                     background=C["bg_2"], fieldbackground=C["bg_2"],
                     foreground=C["fg_1"], bordercolor=C["bg_2"],
-                    rowheight=28, font=F["body"], borderwidth=0)
+                    rowheight=32, font=F["body"], borderwidth=0)
     style.map("Treeview",
               background=[("selected", C["accent_15"])],
               foreground=[("selected", C["fg_0"])])
     style.configure("Treeview.Heading",
                     background=C["bg_4"], foreground=C["fg_3"],
                     relief="flat", borderwidth=0,
-                    font=(_SANS, 9, "bold"), padding=(10, 7))
+                    font=(_SANS, 9, "bold"), padding=(12, 9))
     style.map("Treeview.Heading",
               background=[("active", C["bg_5"])],
               foreground=[("active", C["accent"])])

--- a/ui/shared/cards.py
+++ b/ui/shared/cards.py
@@ -52,7 +52,7 @@ class Card(tk.Frame):
     def __init__(self, parent, title=None, subtitle=None, icon=None,
                  with_actions=False, **kwargs):
         # Pop any user-supplied highlight overrides so super() doesn't collide
-        hl_bg = kwargs.pop('highlightbackground', COLORS['border_2'])
+        hl_bg = kwargs.pop('highlightbackground', COLORS['border_3'])
         hl_th = kwargs.pop('highlightthickness', 1)
         bg = kwargs.pop('bg', COLORS['bg_2'])
         super().__init__(parent, bg=bg,
@@ -62,33 +62,38 @@ class Card(tk.Frame):
 
         # ── Optional header row ──
         if title is not None:
-            head = tk.Frame(self, bg=bg)
-            head.pack(fill='x', padx=18, pady=(14, 12))
+            head_bg = COLORS['bg_3']
+            head = tk.Frame(self, bg=head_bg)
+            head.pack(fill='x')
+            head_inner = tk.Frame(head, bg=head_bg)
+            head_inner.pack(fill='x', padx=18, pady=(15, 13))
 
             if icon:
                 # Icon tile: small accented square holding the emoji
-                ico = tk.Label(head, text=icon,
+                ico = tk.Label(head_inner, text=icon,
                                font=(FONTS['h2'][0], 13),
                                bg=COLORS['accent_08'],
-                               fg=COLORS['accent'],
-                               width=2, padx=4, pady=2)
+                               fg=COLORS['accent_hi'],
+                               width=3, padx=4, pady=5,
+                               highlightbackground=COLORS['accent_lo'],
+                               highlightthickness=1)
                 ico.pack(side='left', padx=(0, 12))
 
-            text_col = tk.Frame(head, bg=bg)
+            text_col = tk.Frame(head_inner, bg=head_bg)
             text_col.pack(side='left', fill='x', expand=True)
             tk.Label(text_col, text=title,
                      font=(FONTS['h3'][0], 11, 'bold'),
-                     bg=bg, fg=COLORS['fg_0'], anchor='w'
+                     bg=head_bg, fg=COLORS['fg_0'], anchor='w'
                      ).pack(fill='x')
             if subtitle:
                 tk.Label(text_col, text=subtitle,
                          font=FONTS['meta'],
-                         bg=bg, fg=COLORS['fg_4'], anchor='w',
+                         bg=head_bg, fg=COLORS['fg_3'], anchor='w',
                          wraplength=900, justify='left'
-                         ).pack(fill='x', pady=(1, 0))
+                         ).pack(fill='x', pady=(3, 0))
 
             # Hairline divider under the header
-            tk.Frame(self, bg=COLORS['border_2'], height=1
+            tk.Frame(self, bg=COLORS['border_3'], height=1
                      ).pack(fill='x')
 
         # ── Optional actions footer ──
@@ -100,14 +105,14 @@ class Card(tk.Frame):
         self.actions = None
         if with_actions:
             self.actions = tk.Frame(self, bg=COLORS['bg_3'])
-            self.actions.pack(side='bottom', fill='x', padx=14, pady=10)
-            tk.Frame(self, bg=COLORS['border_2'], height=1
+            self.actions.pack(side='bottom', fill='x', padx=18, pady=12)
+            tk.Frame(self, bg=COLORS['border_3'], height=1
                      ).pack(side='bottom', fill='x')
 
         # ── Body ── (caller fills this) — packed AFTER actions so it
         # claims the remaining vertical space above the footer.
         self.body = tk.Frame(self, bg=bg)
-        self.body.pack(fill='both', expand=True, padx=18, pady=14)
+        self.body.pack(fill='both', expand=True, padx=20, pady=18)
 
 
 # ─────────────────────────────────────────────────────────────────────────
@@ -143,7 +148,9 @@ class StatusPill(tk.Label):
         super().__init__(parent, text=' ' + text + ' ',
                          bg=bg, fg=fg,
                          font=(FONTS['body'][0], 9, 'bold'),
-                         padx=6, pady=2, bd=0)
+                         padx=8, pady=3, bd=0,
+                         highlightbackground=fg,
+                         highlightthickness=1)
         self._kind = kind
 
     def set(self, kind, text):
@@ -181,7 +188,7 @@ class StatPill(tk.Frame):
     def __init__(self, parent, kind='neutral', count=0, label=''):
         bg = COLORS['bg_3']
         super().__init__(parent, bg=bg,
-                         highlightbackground=COLORS['border_2'],
+                         highlightbackground=COLORS['border_3'],
                          highlightthickness=1)
         self._kind = kind
         self._label_text = label
@@ -689,11 +696,14 @@ class SettingsCard(tk.Frame):
                          highlightthickness=1)
 
         # ── Header (title + optional hint/widget) ──
-        head = tk.Frame(self, bg=bg)
-        head.pack(fill='x', padx=18, pady=(16, 10))
-        tk.Label(head, text=title,
+        head_bg = COLORS['bg_3']
+        head = tk.Frame(self, bg=head_bg)
+        head.pack(fill='x')
+        head_inner = tk.Frame(head, bg=head_bg)
+        head_inner.pack(fill='x', padx=18, pady=(15, 13))
+        tk.Label(head_inner, text=title,
                  font=(FONTS['h3'][0], 12, 'bold'),
-                 bg=bg, fg=COLORS['fg_0'], anchor='w'
+                 bg=head_bg, fg=COLORS['fg_0'], anchor='w'
                  ).pack(side='left')
         if right_widget is not None:
             # The caller built this widget against a different parent;
@@ -703,13 +713,13 @@ class SettingsCard(tk.Frame):
             except Exception:
                 pass
         elif hint:
-            tk.Label(head, text=hint,
+            tk.Label(head_inner, text=hint,
                      font=FONTS['mono_sm'],
-                     bg=bg, fg=COLORS['fg_4']
+                     bg=head_bg, fg=COLORS['fg_3']
                      ).pack(side='right')
 
         # Hairline divider under the header
-        tk.Frame(self, bg=COLORS['border_2'], height=1).pack(fill='x')
+        tk.Frame(self, bg=COLORS['border_3'], height=1).pack(fill='x')
 
         # ── Body — rows pack here ──
         self.body = tk.Frame(self, bg=bg)
@@ -732,10 +742,10 @@ def settings_row(parent, label, description=None, with_divider=True):
     """
     bg = COLORS['bg_2']
     row = tk.Frame(parent, bg=bg)
-    row.pack(fill='x', padx=18, pady=10)
+    row.pack(fill='x', padx=20, pady=12)
 
     # Use grid for the 3 columns so labels align across rows
-    row.grid_columnconfigure(0, weight=0, minsize=200)
+    row.grid_columnconfigure(0, weight=0, minsize=220)
     row.grid_columnconfigure(1, weight=1)
     row.grid_columnconfigure(2, weight=0)
 
@@ -743,7 +753,7 @@ def settings_row(parent, label, description=None, with_divider=True):
     label_col = tk.Frame(row, bg=bg)
     label_col.grid(row=0, column=0, sticky='w', padx=(0, 16))
     tk.Label(label_col, text=label,
-             font=(FONTS['body'][0], 11),
+             font=(FONTS['body'][0], 10, 'bold'),
              bg=bg, fg=COLORS['fg_1'], anchor='w'
              ).pack(fill='x')
     if description:
@@ -764,7 +774,7 @@ def settings_row(parent, label, description=None, with_divider=True):
     # ── Optional hairline below the row ──
     if with_divider:
         tk.Frame(parent, bg=COLORS['border_1'], height=1
-                 ).pack(fill='x', padx=18)
+                 ).pack(fill='x', padx=20)
 
     return row, control, actions
 

--- a/ui/shared/empty_state.py
+++ b/ui/shared/empty_state.py
@@ -40,25 +40,30 @@ class EmptyState(tk.Frame):
     """
 
     def __init__(self, parent, icon="\u2014", title="Nothing here yet",
-                 description="", bg="bg_1", **kwargs):
+                 description="", bg="bg_2", **kwargs):
         self._bg = get_color(bg)
         super().__init__(parent, bg=self._bg,
-                         highlightthickness=0, bd=0, **kwargs)
+                         highlightbackground=get_color("border_3"),
+                         highlightthickness=1, bd=0, **kwargs)
 
         center = tk.Frame(self, bg=self._bg)
         center.place(relx=0.5, rely=0.5, anchor="center")
 
-        tk.Label(center, text=icon, bg=self._bg,
-                 fg=get_color("fg_5"),
-                 font=(get_font("h1")[0], 34, "normal")).pack()
+        tk.Label(center, text=icon, bg=get_color("accent_08"),
+                 fg=get_color("accent_hi"),
+                 font=(get_font("h1")[0], 24, "normal"),
+                 width=3, height=2,
+                 highlightbackground=get_color("accent_lo"),
+                 highlightthickness=1).pack()
 
         tk.Label(center, text=title, bg=self._bg,
-                 fg=get_color("fg_2"), font=get_font("h3")).pack(
+                 fg=get_color("fg_1"),
+                 font=(get_font("h3")[0], 12, "bold")).pack(
                      pady=(SPACING["md"], 0))
 
         if description:
             tk.Label(center, text=description, bg=self._bg,
-                     fg=get_color("fg_5"), font=get_font("body"),
+                     fg=get_color("fg_4"), font=get_font("body"),
                      wraplength=360, justify="center").pack(
                          pady=(SPACING["xs"], 0))
 
@@ -81,27 +86,35 @@ class SectionGroup(tk.Frame):
     """
 
     def __init__(self, parent, title="", description="",
-                 bg="bg_1", **kwargs):
+                 bg="bg_2", **kwargs):
         self._bg = get_color(bg)
         super().__init__(parent, bg=self._bg,
-                         highlightthickness=0, bd=0, **kwargs)
+                         highlightbackground=get_color("border_3"),
+                         highlightthickness=1, bd=0, **kwargs)
+
+        head = tk.Frame(self, bg=get_color("bg_3"))
+        head.pack(fill="x")
+        head_inner = tk.Frame(head, bg=get_color("bg_3"))
+        head_inner.pack(fill="x", padx=SPACING["lg"], pady=SPACING["md"])
 
         if title:
-            tk.Label(self, text=title.upper(), bg=self._bg,
+            tk.Label(head_inner, text=title.upper(),
+                     bg=get_color("bg_3"),
                      fg=get_color("accent"), font=get_font("eyebrow"),
                      anchor="w").pack(fill="x")
         if description:
-            tk.Label(self, text=description, bg=self._bg,
+            tk.Label(head_inner, text=description,
+                     bg=get_color("bg_3"),
                      fg=get_color("fg_4"), font=get_font("label"),
                      anchor="w", justify="left").pack(
                          fill="x", pady=(SPACING["xxs"], 0))
 
         # hairline divider
-        tk.Frame(self, bg=get_color("border_2"), height=1).pack(
-            fill="x", pady=(SPACING["sm"], SPACING["md"]))
+        tk.Frame(self, bg=get_color("border_3"), height=1).pack(fill="x")
 
         self.body = tk.Frame(self, bg=self._bg)
-        self.body.pack(fill="both", expand=True)
+        self.body.pack(fill="both", expand=True,
+                       padx=SPACING["lg"], pady=SPACING["lg"])
 
 
 # ── harmless self-test / demo ────────────────────────────────────────

--- a/ui/shared/forms.py
+++ b/ui/shared/forms.py
@@ -44,41 +44,54 @@ class DropZone(tk.Frame):
 
     def __init__(self, parent, on_drop=None, on_click=None,
                  hint=None, glyph='\u2913'):
-        bg = COLORS['bg_2']
+        bg = COLORS['bg_3']
         super().__init__(parent, bg=bg,
                          highlightbackground=COLORS['border_3'],
-                         highlightthickness=1)
+                         highlightthickness=1,
+                         takefocus=1 if on_click else 0)
         self._on_drop = on_drop
         self._on_click = on_click
+        self._focused = False
         self._idle_bg = bg
         self._hover_bg = COLORS['accent_08']
         self._idle_border = COLORS['border_3']
         self._hover_border = COLORS['accent']
 
         inner = tk.Frame(self, bg=bg)
-        inner.pack(fill='both', expand=True, padx=22, pady=22)
+        inner.pack(fill='both', expand=True, padx=20, pady=18)
+        self._inner = inner
 
         self._glyph_lbl = tk.Label(inner, text=glyph,
-                                   font=(FONTS['body'][0], 24),
-                                   bg=bg, fg=COLORS['fg_5'])
-        self._glyph_lbl.pack()
+                                   font=(FONTS['body'][0], 22, 'bold'),
+                                   bg=COLORS['accent_08'],
+                                   fg=COLORS['accent_hi'],
+                                   width=3, height=2,
+                                   highlightbackground=COLORS['accent_lo'],
+                                   highlightthickness=1)
+        self._glyph_lbl.pack(side='left', padx=(0, 14))
 
-        self._main_lbl = tk.Label(inner,
+        self._text_col = tk.Frame(inner, bg=bg)
+        self._text_col.pack(side='left', fill='x', expand=True)
+        self._main_lbl = tk.Label(self._text_col,
                                   text='Drop a game folder here',
                                   font=(FONTS['body'][0], 11, 'bold'),
-                                  bg=bg, fg=COLORS['fg_2'])
-        self._main_lbl.pack(pady=(6, 0))
+                                  bg=bg, fg=COLORS['fg_1'],
+                                  anchor='w')
+        self._main_lbl.pack(fill='x')
 
         if hint:
-            self._hint_lbl = tk.Label(inner, text=hint,
+            self._hint_lbl = tk.Label(self._text_col, text=hint,
                                       font=FONTS['meta'],
-                                      bg=bg, fg=COLORS['fg_5'])
-            self._hint_lbl.pack(pady=(2, 0))
+                                      bg=bg, fg=COLORS['fg_4'],
+                                      anchor='w', justify='left',
+                                      wraplength=720)
+            self._hint_lbl.pack(fill='x', pady=(4, 0))
         else:
             self._hint_lbl = None
 
         # ── Hover and click feedback on the whole zone ──
-        for w in [self, inner, self._glyph_lbl, self._main_lbl] + (
+        for w in [self, inner, self._text_col,
+                  self._glyph_lbl, self._main_lbl] + (
                 [self._hint_lbl] if self._hint_lbl else []):
             w.bind('<Enter>', self._on_enter, add='+')
             w.bind('<Leave>', self._on_leave, add='+')
@@ -88,6 +101,11 @@ class DropZone(tk.Frame):
                     w.config(cursor='hand2')
                 except Exception:
                     pass
+        if on_click:
+            self.bind('<FocusIn>', self._on_focus_in, add='+')
+            self.bind('<FocusOut>', self._on_focus_out, add='+')
+            self.bind('<Return>', self._on_click_evt, add='+')
+            self.bind('<space>', self._on_click_evt, add='+')
 
         # ── Drag-and-drop registration (tkinterdnd2 if available) ──
         try:
@@ -106,24 +124,20 @@ class DropZone(tk.Frame):
             self.configure(highlightbackground=self._hover_border,
                            highlightthickness=1)
             self._main_lbl.configure(bg=self._hover_bg)
-            self._glyph_lbl.configure(bg=self._hover_bg, fg=COLORS['accent'])
-            for child in self.winfo_children():
-                try:
-                    child.configure(bg=self._hover_bg)
-                except Exception:
-                    pass
+            self._glyph_lbl.configure(
+                bg=COLORS['accent_15'], fg=COLORS['accent_hi'])
+            self._inner.configure(bg=self._hover_bg)
+            self._text_col.configure(bg=self._hover_bg)
             if self._hint_lbl:
                 self._hint_lbl.configure(bg=self._hover_bg)
         else:
             self.configure(highlightbackground=self._idle_border,
                            highlightthickness=1)
             self._main_lbl.configure(bg=self._idle_bg)
-            self._glyph_lbl.configure(bg=self._idle_bg, fg=COLORS['fg_5'])
-            for child in self.winfo_children():
-                try:
-                    child.configure(bg=self._idle_bg)
-                except Exception:
-                    pass
+            self._glyph_lbl.configure(
+                bg=COLORS['accent_08'], fg=COLORS['accent_hi'])
+            self._inner.configure(bg=self._idle_bg)
+            self._text_col.configure(bg=self._idle_bg)
             if self._hint_lbl:
                 self._hint_lbl.configure(bg=self._idle_bg)
 
@@ -131,10 +145,22 @@ class DropZone(tk.Frame):
         self._set_active(True)
 
     def _on_leave(self, _e=None):
+        self._set_active(self._focused)
+
+    def _on_focus_in(self, _e=None):
+        self._focused = True
+        self._set_active(True)
+
+    def _on_focus_out(self, _e=None):
+        self._focused = False
         self._set_active(False)
 
     def _on_click_evt(self, _e=None):
         if self._on_click:
+            try:
+                self.focus_set()
+            except Exception:
+                pass
             try:
                 self._on_click()
             except Exception:
@@ -201,8 +227,8 @@ class LabeledField(tk.Frame):
         lbl_row.pack(fill='x')
 
         tk.Label(lbl_row, text=label,
-                 font=FONTS['label'],
-                 bg=row_bg, fg=COLORS['fg_3'], anchor='w'
+                 font=(FONTS['body'][0], 9, 'bold'),
+                 bg=row_bg, fg=COLORS['fg_2'], anchor='w'
                  ).pack(side='left')
         if required:
             tk.Label(lbl_row, text='  *',
@@ -227,9 +253,19 @@ class LabeledField(tk.Frame):
                               insertbackground=COLORS['field_fg'],
                               selectbackground=COLORS['accent'],
                               selectforeground=COLORS['fg_0'],
-                              relief='flat', bd=6,
+                              relief='flat', bd=9,
                               state=('readonly' if readonly else 'normal'))
         self.entry.pack(side='left', fill='x', expand=True)
+        self.entry.bind(
+            '<FocusIn>',
+            lambda _e: input_wrap.configure(
+                highlightbackground=COLORS['accent']),
+            add='+')
+        self.entry.bind(
+            '<FocusOut>',
+            lambda _e: input_wrap.configure(
+                highlightbackground=COLORS['border_3']),
+            add='+')
 
         self.button = None
         if on_browse:
@@ -239,7 +275,7 @@ class LabeledField(tk.Frame):
                                     activebackground=COLORS['bg_5'],
                                     activeforeground=COLORS['accent'],
                                     relief='flat', bd=0,
-                                    padx=14, pady=6,
+                                    padx=16, pady=8,
                                     cursor='hand2',
                                     command=on_browse)
             self.button.pack(side='right')
@@ -272,6 +308,7 @@ class SegmentedToggle(tk.Frame):
         super().__init__(parent, bg=row_bg)
         self._var = var
         self._on_change = on_change
+        self._focused = False
 
         # The pill body is itself a labeled Frame with a 1px border.
         self._pill_bg_off = COLORS['bg_2']
@@ -282,19 +319,25 @@ class SegmentedToggle(tk.Frame):
         self._pill_fg_on  = COLORS['accent']
 
         self._pill = tk.Frame(self,
-                              highlightthickness=1)
+                              highlightthickness=1,
+                              takefocus=1,
+                              cursor='hand2')
         self._pill.pack()
 
         display = ((glyph + ' ') if glyph else '') + text
         self._lbl = tk.Label(self._pill, text=display,
                              font=FONTS['meta'],
-                             padx=10, pady=4,
+                             padx=12, pady=6,
                              cursor='hand2')
         self._lbl.pack()
 
         # Click anywhere on the pill (or its label) toggles the var.
         for w in (self._pill, self._lbl):
-            w.bind('<Button-1>', lambda e: self._toggle())
+            w.bind('<Button-1>', self._activate)
+        self._pill.bind('<Return>', self._activate)
+        self._pill.bind('<space>', self._activate)
+        self._pill.bind('<FocusIn>', self._on_focus_in)
+        self._pill.bind('<FocusOut>', self._on_focus_out)
 
         # Initial paint
         self._repaint()
@@ -318,10 +361,26 @@ class SegmentedToggle(tk.Frame):
             except Exception:
                 pass
 
+    def _activate(self, _e=None):
+        try:
+            self._pill.focus_set()
+        except Exception:
+            pass
+        self._toggle()
+
+    def _on_focus_in(self, _e=None):
+        self._focused = True
+        self._repaint()
+
+    def _on_focus_out(self, _e=None):
+        self._focused = False
+        self._repaint()
+
     def _repaint(self):
         on = bool(self._var.get())
         bg = self._pill_bg_on if on else self._pill_bg_off
-        bd = self._pill_border_on if on else self._pill_border_off
+        bd = (COLORS['accent_hi'] if self._focused else
+              self._pill_border_on if on else self._pill_border_off)
         fg = self._pill_fg_on if on else self._pill_fg_off
         self._pill.configure(bg=bg, highlightbackground=bd)
         self._lbl.configure(bg=bg, fg=fg)

--- a/ui/shared/log_view.py
+++ b/ui/shared/log_view.py
@@ -55,7 +55,7 @@ class ConsoleView(tk.Frame):
 
     def __init__(self, parent, **kwargs):
         bg = _TERM_BG
-        bd_color = COLORS['border_3']
+        bd_color = COLORS['border_4']
         super().__init__(parent, bg=bg,
                          highlightbackground=bd_color,
                          highlightthickness=1,
@@ -64,7 +64,7 @@ class ConsoleView(tk.Frame):
         # Thin green top-rule — the mock has a horizontal accent line at
         # the top of the log surface. We approximate with a 1-px Frame.
         # bg picks up the dim klog-green at low intensity.
-        rule = tk.Frame(self, bg='#1a3322', height=1)
+        rule = tk.Frame(self, bg=COLORS['success'], height=2)
         rule.pack(fill='x')
 
         # ── Scrollable Text widget ──
@@ -82,10 +82,10 @@ class ConsoleView(tk.Frame):
                             insertbackground=_TERM_GREEN,
                             selectbackground='#1a3322',
                             selectforeground=COLORS['fg_0'],
-                            relief='flat', bd=8,
+                            relief='flat', bd=12,
                             state='disabled', wrap='word',
                             yscrollcommand=sb.set,
-                            spacing1=1, spacing3=1)
+                            spacing1=2, spacing3=2)
         self.text.pack(side='left', fill='both', expand=True)
         sb.config(command=self.text.yview)
 

--- a/ui/shared/page_head.py
+++ b/ui/shared/page_head.py
@@ -29,7 +29,7 @@ from tkinter_theme import COLORS, FONTS
 
 
 def make_themed_button(parent, text, command, kind='primary',
-                        icon=None, font_size=10, padx=14, pady=7,
+                        icon=None, font_size=10, padx=16, pady=8,
                         state='normal'):
     """Build a tk.Button styled like the design-system btn-* classes.
 
@@ -65,7 +65,7 @@ def make_themed_button(parent, text, command, kind='primary',
                          COLORS['warn_hi'], '#1a0e00'),
         'danger':       (COLORS['danger'],  COLORS['fg_0'],
                          COLORS['danger_hi'], COLORS['fg_0']),
-        'ghost':        (COLORS['bg_2'],    COLORS['fg_3'],
+        'ghost':        (COLORS['bg_3'],    COLORS['fg_2'],
                          COLORS['bg_4'],    COLORS['fg_1']),
     }
     bg, fg, abg, afg = schemes.get(kind, schemes['primary'])
@@ -76,7 +76,10 @@ def make_themed_button(parent, text, command, kind='primary',
                     activebackground=abg, activeforeground=afg,
                     relief='flat', bd=0,
                     padx=padx, pady=pady,
-                    cursor='hand2', state=state,
+                    cursor='hand2', state=state, takefocus=1,
+                    highlightthickness=1,
+                    highlightbackground=bg,
+                    highlightcolor=COLORS['accent_hi'],
                     command=command)
     if kind == 'ghost':
         btn.configure(highlightbackground=COLORS['border_3'],
@@ -87,11 +90,13 @@ def make_themed_button(parent, text, command, kind='primary',
 def info_banner(parent, text, on_click=None):
     """Slim accent-tinted info bar."""
     bg = COLORS['accent_08']
-    border = COLORS['accent_15']
+    border = COLORS['accent_lo']
     bar = tk.Frame(parent, bg=bg,
                    highlightbackground=border, highlightthickness=1)
+    tk.Frame(bar, bg=COLORS['accent'], width=3).pack(
+        side='left', fill='y')
     inner = tk.Frame(bar, bg=bg)
-    inner.pack(fill='x', padx=14, pady=10)
+    inner.pack(side='left', fill='x', expand=True, padx=14, pady=11)
 
     ico = tk.Label(inner, text='i',
                    bg=COLORS['accent'], fg=COLORS['fg_0'],
@@ -121,27 +126,34 @@ def page_head(parent, badge_emoji, title_text, subtitle_text):
 
     Pack with `pady=(14, 12)` for the Build-tab standard spacing.
     """
-    bg = COLORS['bg_1']
-    head = tk.Frame(parent, bg=bg)
+    bg = COLORS['bg_2']
+    head = tk.Frame(parent, bg=bg,
+                    highlightbackground=COLORS['border_3'],
+                    highlightthickness=1)
+    tk.Frame(head, bg=COLORS['accent'], width=4).pack(
+        side='left', fill='y')
+    inner = tk.Frame(head, bg=bg)
+    inner.pack(side='left', fill='x', expand=True, padx=18, pady=16)
 
-    badge = tk.Label(head, text=badge_emoji,
-                     bg=COLORS['accent'], fg=COLORS['fg_0'],
-                     font=(FONTS['body'][0], 18, 'bold'),
+    badge = tk.Label(inner, text=badge_emoji,
+                     bg=COLORS['accent_08'], fg=COLORS['accent_hi'],
+                     font=(FONTS['body'][0], 16, 'bold'),
                      width=3, height=2, padx=4, pady=0,
-                     highlightbackground=COLORS['accent_pressed'],
+                     highlightbackground=COLORS['accent_lo'],
                      highlightthickness=1)
     badge.pack(side='left', padx=(0, 14))
 
-    text_col = tk.Frame(head, bg=bg)
+    text_col = tk.Frame(inner, bg=bg)
     text_col.pack(side='left', fill='x', expand=True)
     tk.Label(text_col, text=title_text,
-             font=(FONTS['h2'][0], 18, 'bold'),
+             font=(FONTS['h2'][0], 17, 'bold'),
              bg=bg, fg=COLORS['fg_0'], anchor='w'
              ).pack(fill='x')
     tk.Label(text_col, text=subtitle_text,
              font=FONTS['meta'],
-             bg=bg, fg=COLORS['fg_4'], anchor='w'
-             ).pack(fill='x', pady=(2, 0))
+             bg=bg, fg=COLORS['fg_3'], anchor='w',
+             justify='left', wraplength=900
+             ).pack(fill='x', pady=(4, 0))
 
     return head
 
@@ -164,8 +176,8 @@ def field_block(parent, label_text, var, on_browse=None,
     lbl_row = tk.Frame(block, bg=COLORS['bg_2'])
     lbl_row.pack(fill='x')
     tk.Label(lbl_row, text=label_text,
-             font=FONTS['label'],
-             bg=COLORS['bg_2'], fg=COLORS['fg_3'], anchor='w'
+             font=(FONTS['body'][0], 9, 'bold'),
+             bg=COLORS['bg_2'], fg=COLORS['fg_2'], anchor='w'
              ).pack(side='left')
     if hint:
         tk.Label(lbl_row, text='  \u2022  ' + hint,
@@ -184,7 +196,7 @@ def field_block(parent, label_text, var, on_browse=None,
                      insertbackground=COLORS['field_fg'],
                      selectbackground=COLORS['accent'],
                      selectforeground=COLORS['fg_0'],
-                     relief='flat', bd=8)
+                     relief='flat', bd=9)
     entry.pack(side='left', fill='x', expand=True)
 
     if on_browse:
@@ -194,7 +206,7 @@ def field_block(parent, label_text, var, on_browse=None,
                   activebackground=COLORS['bg_5'],
                   activeforeground=COLORS['accent'],
                   relief='flat', bd=0,
-                  padx=14, pady=6,
+                  padx=16, pady=8,
                   cursor='hand2',
                   command=on_browse
                   ).pack(side='right')

--- a/ui/shared/sidebar.py
+++ b/ui/shared/sidebar.py
@@ -43,34 +43,36 @@ class NavItem(tk.Frame):
 
     def __init__(self, parent, key, label, icon=None, on_select=None,
                  **kwargs):
-        super().__init__(parent, bg=get_color("bg_1"),
-                         highlightthickness=0, bd=0, **kwargs)
+        super().__init__(parent, bg=get_color("bg_0"),
+                         highlightthickness=0, bd=0, takefocus=1, **kwargs)
         self.key = key
         self.label = label             # kept for compact-mode tooltips (5B)
         self._on_select = on_select
         self._active = False
         self._compact = False
+        self._focused = False
 
         # accent bar on the left edge — shown only when active
-        self._bar = tk.Frame(self, bg=get_color("bg_1"), width=3)
+        self._bar = tk.Frame(self, bg=get_color("bg_0"), width=4)
         self._bar.pack(side="left", fill="y")
 
-        self._inner = tk.Frame(self, bg=get_color("bg_1"))
+        self._inner = tk.Frame(self, bg=get_color("bg_0"))
         self._inner.pack(side="left", fill="both", expand=True)
 
-        pad = SPACING["sm"]
+        pad = 10
         if icon:
             self._icon = tk.Label(self._inner, text=icon,
-                                  bg=get_color("bg_1"),
+                                  bg=get_color("bg_2"),
                                   fg=get_color("fg_4"),
-                                  font=get_font("body"))
-            self._icon.pack(side="left", padx=(SPACING["md"], SPACING["sm"]),
-                            pady=pad)
+                                  font=get_font("body_b"),
+                                  width=3, padx=1, pady=3)
+            self._icon.pack(
+                side="left", padx=(SPACING["md"], SPACING["sm"]), pady=5)
         else:
             self._icon = None
 
         self._label = tk.Label(self._inner, text=label,
-                               bg=get_color("bg_1"),
+                               bg=get_color("bg_0"),
                                fg=get_color("fg_3"),
                                font=get_font("body"), anchor="w")
         self._label.pack(side="left", fill="x", expand=True,
@@ -83,6 +85,10 @@ class NavItem(tk.Frame):
             w.bind("<Enter>", self._enter)
             w.bind("<Leave>", self._leave)
             w.configure(cursor="hand2")
+        self.bind("<FocusIn>", self._focus_in)
+        self.bind("<FocusOut>", self._focus_out)
+        self.bind("<Return>", self._click)
+        self.bind("<space>", self._click)
 
     # ── compact (collapsed-rail) mode ─────────────────────────────────
     def set_compact(self, compact):
@@ -101,12 +107,12 @@ class NavItem(tk.Frame):
                 pass
             if self._icon:
                 self._icon.pack_configure(
-                    padx=SPACING["sm"], pady=SPACING["sm"])
+                    padx=(10, 0), pady=5)
         else:
             # Restore icon padding, then re-show the label after it.
             if self._icon:
                 self._icon.pack_configure(
-                    padx=(SPACING["md"], SPACING["sm"]), pady=SPACING["sm"])
+                    padx=(SPACING["md"], SPACING["sm"]), pady=5)
             try:
                 self._label.pack(side="left", fill="x", expand=True,
                                  padx=(0 if self._icon else SPACING["md"],
@@ -133,23 +139,31 @@ class NavItem(tk.Frame):
 
     def _render(self):
         if self._active:
-            bg = get_color("accent_08")       # theme 'active' fill convention
+            bg = get_color("accent_08")
             fg = get_color("accent_hi")
             bar = get_color("accent")
             icon_fg = get_color("accent")
+            icon_bg = get_color("accent_15")
             font = get_font("body_b")
         else:
-            bg = get_color("bg_1")
+            bg = get_color("bg_0")
             fg = get_color("fg_3")
-            bar = get_color("bg_1")
+            bar = get_color("bg_0")
             icon_fg = get_color("fg_4")
+            icon_bg = get_color("bg_2")
             font = get_font("body")
+        if self._focused and not self._active:
+            bg = get_color("bg_2")
+            fg = get_color("fg_1")
+            bar = get_color("accent")
+            icon_fg = get_color("accent")
+            icon_bg = get_color("accent_08")
         self._bar.configure(bg=bar)
         for w in (self, self._inner, self._label):
             w.configure(bg=bg)
         self._label.configure(fg=fg, font=font)
         if self._icon:
-            self._icon.configure(bg=bg, fg=icon_fg)
+            self._icon.configure(bg=icon_bg, fg=icon_fg)
 
     # ── events ───────────────────────────────────────────────────────
     def _enter(self, _e=None):
@@ -157,15 +171,28 @@ class NavItem(tk.Frame):
             for w in (self, self._inner, self._label):
                 w.configure(bg=get_color("bg_2"))
             if self._icon:
-                self._icon.configure(bg=get_color("bg_2"))
+                self._icon.configure(
+                    bg=get_color("bg_3"), fg=get_color("fg_1"))
 
     def _leave(self, _e=None):
         if not self._active:
             self._render()
 
     def _click(self, _e=None):
+        try:
+            self.focus_set()
+        except Exception:
+            pass
         if callable(self._on_select):
             self._on_select(self.key)
+
+    def _focus_in(self, _e=None):
+        self._focused = True
+        self._render()
+
+    def _focus_out(self, _e=None):
+        self._focused = False
+        self._render()
 
 
 class Sidebar(tk.Frame):
@@ -187,8 +214,8 @@ class Sidebar(tk.Frame):
     assigns; until then, clicking items is inert.
     """
 
-    def __init__(self, parent, width=210, rail_width=60, **kwargs):
-        super().__init__(parent, bg=get_color("bg_1"), width=width,
+    def __init__(self, parent, width=224, rail_width=64, **kwargs):
+        super().__init__(parent, bg=get_color("bg_0"), width=width,
                          highlightthickness=0, bd=0, **kwargs)
         self.pack_propagate(False)
         self.on_select = None          # host assigns a callable(key)
@@ -205,21 +232,35 @@ class Sidebar(tk.Frame):
 
         # Toggle control pinned at the very top, above the groups.
         self._toggle = tk.Label(self, text="\u2039\u2039",   # ‹‹ expanded
-                                bg=get_color("bg_1"), fg=get_color("fg_5"),
+                                bg=get_color("bg_0"), fg=get_color("fg_5"),
                                 font=get_font("body"), anchor="e",
-                                cursor="hand2")
+                                cursor="hand2", takefocus=1,
+                                highlightthickness=1,
+                                highlightbackground=get_color("bg_0"))
         self._toggle.pack(side="top", fill="x",
-                          padx=SPACING["md"], pady=(SPACING["sm"], 0))
+                          padx=SPACING["md"], pady=(SPACING["md"], SPACING["xs"]))
         self._toggle.bind("<Button-1>", lambda _e: self.toggle())
+        self._toggle.bind("<Return>", lambda _e: self.toggle())
+        self._toggle.bind("<space>", lambda _e: self.toggle())
+        self._toggle.bind(
+            "<FocusIn>",
+            lambda _e: self._toggle.configure(
+                fg=get_color("fg_1"),
+                highlightbackground=get_color("accent")))
+        self._toggle.bind(
+            "<FocusOut>",
+            lambda _e: self._toggle.configure(
+                fg=get_color("fg_5"),
+                highlightbackground=get_color("bg_0")))
         self._toggle.bind("<Enter>",
                           lambda _e: self._toggle.configure(fg=get_color("fg_3")))
         self._toggle.bind("<Leave>",
                           lambda _e: self._toggle.configure(fg=get_color("fg_5")))
 
-        self._body = tk.Frame(self, bg=get_color("bg_1"))
+        self._body = tk.Frame(self, bg=get_color("bg_0"))
         self._body.pack(side="top", fill="both", expand=True)
 
-        self._footer = tk.Frame(self, bg=get_color("bg_1"))
+        self._footer = tk.Frame(self, bg=get_color("bg_0"))
         self._footer.pack(side="bottom", fill="x")
 
     # ── building ─────────────────────────────────────────────────────
@@ -234,7 +275,7 @@ class Sidebar(tk.Frame):
             self._group_divs.append(div)
             self._build_order.append(div)
         lbl = tk.Label(self._body, text=title.upper(),
-                       bg=get_color("bg_1"), fg=get_color("fg_5"),
+                       bg=get_color("bg_0"), fg=get_color("fg_5"),
                        font=get_font("eyebrow"), anchor="w")
         lbl.pack(fill="x", padx=SPACING["md"],
                  pady=((SPACING["lg"] if first else SPACING["sm"]),

--- a/ui/tab_home.py
+++ b/ui/tab_home.py
@@ -1,17 +1,12 @@
-"""
-ui/tab_home.py — Home dashboard (v4.0 Entry 2 Phase 1).
+"""Home control-center dashboard.
 
-The landing surface for the app: goal-first cards that route the user to the
-right workflow. Every card routes through the EXISTING _switch_tab router —
-no new navigation, no backend logic. Additive: the top bar and sidebar are
-untouched; this is simply a new destination.
-
-Presentation only. All colours/fonts via COLORS/FONTS tokens (standing rule).
+Presentation-only landing surface. Every action routes through the existing
+tab registry and introduces no workflow or backend behavior.
 """
 
 import tkinter as tk
 
-from tkinter_theme import COLORS, FONTS
+from tkinter_theme import COLORS, FONTS, SPACING
 
 from exfat_builder import _
 from ui.shared.page_head import make_themed_button
@@ -19,104 +14,266 @@ from ui.shared.scroll import attach_scroll
 
 
 def build_home_tab(parent, app):
-    """Build the Home dashboard into `parent`.
-
-    Cards call app._switch_tab(<registry key>) — the same router the top bar
-    and sidebar use. No new state, no backend change.
-    """
+    """Build the Home dashboard into ``parent``."""
     parent.configure(bg=COLORS['bg_1'])
 
-    # ── Page-level scroll (consistent with the PS5 Overview page) ──
     page_canvas = tk.Canvas(parent, bg=COLORS['bg_1'], highlightthickness=0)
-    page_sb = tk.Scrollbar(parent, orient='vertical',
-                           command=page_canvas.yview,
-                           bg=COLORS['bg_3'], troughcolor=COLORS['bg_1'])
+    page_sb = tk.Scrollbar(
+        parent, orient='vertical', command=page_canvas.yview,
+        bg=COLORS['bg_3'], troughcolor=COLORS['bg_1'])
     page_canvas.configure(yscrollcommand=page_sb.set)
     page_sb.pack(side='right', fill='y')
     page_canvas.pack(side='left', fill='both', expand=True)
 
     body = tk.Frame(page_canvas, bg=COLORS['bg_1'])
-    _win = page_canvas.create_window((0, 0), window=body, anchor='nw')
-    body.bind('<Configure>', lambda e:
-              page_canvas.configure(scrollregion=page_canvas.bbox('all')))
-    page_canvas.bind('<Configure>', lambda e:
-                     page_canvas.itemconfig(_win, width=e.width))
+    window_id = page_canvas.create_window((0, 0), window=body, anchor='nw')
+    body.bind(
+        '<Configure>',
+        lambda _e: page_canvas.configure(
+            scrollregion=page_canvas.bbox('all')))
+    page_canvas.bind(
+        '<Configure>',
+        lambda event: page_canvas.itemconfig(window_id, width=event.width))
     attach_scroll(page_canvas)
 
     def _go(key):
-        # Route through the existing router. Guarded so a missing router
-        # (very early build order) never raises.
         try:
-            getattr(app, '_switch_tab', lambda k: None)(key)
+            getattr(app, '_switch_tab', lambda _key: None)(key)
         except Exception:
             pass
 
-    # ── Hero / welcome header ──
-    hero = tk.Frame(body, bg=COLORS['bg_1'])
-    hero.pack(fill='x', padx=24, pady=(20, 6))
-    tk.Label(hero, text=_('exFAT Image Builder'),
-             font=(FONTS['h1'][0], 22, 'bold'),
-             bg=COLORS['bg_1'], fg=COLORS['fg_0'], anchor='w'
-             ).pack(anchor='w')
-    tk.Label(hero, text=_('What would you like to do?'),
-             font=FONTS['body'], bg=COLORS['bg_1'], fg=COLORS['fg_4'],
-             anchor='w').pack(anchor='w', pady=(2, 0))
+    content = tk.Frame(body, bg=COLORS['bg_1'])
+    content.pack(fill='x', padx=SPACING['xxl'], pady=(SPACING['xl'], 28))
 
-    # ── Primary goal-first cards ──
-    section = tk.Frame(body, bg=COLORS['bg_1'])
-    section.pack(fill='x', padx=24, pady=(14, 10))
+    hero = tk.Frame(
+        content, bg=COLORS['bg_2'],
+        highlightbackground=COLORS['border_3'], highlightthickness=1)
+    hero.pack(fill='x')
+    tk.Frame(hero, bg=COLORS['accent'], width=4).pack(side='left', fill='y')
 
-    grid = tk.Frame(section, bg=COLORS['bg_1'])
-    grid.pack(fill='x')
-    _COLS = 3
-    for c in range(_COLS):
-        grid.grid_columnconfigure(c, weight=1, uniform='homecard')
+    hero_inner = tk.Frame(hero, bg=COLORS['bg_2'])
+    hero_inner.pack(fill='both', expand=True, padx=24, pady=22)
 
-    # (registry key, icon, title, description). Routes are existing keys.
-    cards = [
-        ('unibuild', '\U0001f6e0', _('Build Image'),
-         _('Create a new image from a game folder.')),
-        ('extract',  '\U0001f4e4', _('Extract Image'),
-         _('Unpack an image back into files and folders.')),
-        ('convert',  '\U0001f504', _('Convert Image'),
-         _('Change an existing image between exFAT and ffpkg.')),
-        ('ps5',      '\U0001f3ae', _('PS5 Tools'),
-         _('Connect to your PS5: transfer, payloads, kernel log.')),
-        ('library',  '\U0001f4da', _('Library'),
-         _('Browse and manage your local game images.')),
-        ('report',   '\U0001f41e', _('Report Issue'),
-         _('Report a problem or get help.')),
-    ]
+    hero_copy = tk.Frame(hero_inner, bg=COLORS['bg_2'])
+    hero_copy.pack(fill='x')
+    tk.Label(
+        hero_copy, text=_('CONTROL CENTER'),
+        font=FONTS['eyebrow'], bg=COLORS['bg_2'], fg=COLORS['accent'],
+        anchor='w').pack(fill='x')
+    tk.Label(
+        hero_copy, text=_('What would you like to do?'),
+        font=(FONTS['h1'][0], 24, 'bold'),
+        bg=COLORS['bg_2'], fg=COLORS['fg_0'], anchor='w'
+    ).pack(fill='x', pady=(6, 0))
+    tk.Label(
+        hero_copy,
+        text=_(
+            'Build, inspect, organize, and deploy game images from one '
+            'workspace.'),
+        font=FONTS['body'], bg=COLORS['bg_2'], fg=COLORS['fg_3'],
+        anchor='w', justify='left', wraplength=560
+    ).pack(fill='x', pady=(6, 0))
 
-    def _make_card(col_idx, key, icon, title, desc):
-        r, c = divmod(col_idx, _COLS)
-        card = tk.Frame(grid, bg=COLORS['bg_3'],
-                        highlightbackground=COLORS['border_2'],
-                        highlightthickness=1)
-        card.grid(row=r, column=c, sticky='nsew',
-                  padx=(0 if c == 0 else 12, 0), pady=(0, 12))
+    hero_actions = tk.Frame(hero_copy, bg=COLORS['bg_2'])
+    hero_actions.pack(fill='x', pady=(18, 0))
+    make_themed_button(
+        hero_actions, _('Build Image'), command=lambda: _go('unibuild'),
+        kind='primary', icon='+', padx=20, pady=9
+    ).pack(side='left')
+    make_themed_button(
+        hero_actions, _('Open Library'), command=lambda: _go('library'),
+        kind='ghost', padx=18, pady=9
+    ).pack(side='left', padx=(8, 0))
 
-        inner = tk.Frame(card, bg=COLORS['bg_3'])
-        inner.pack(fill='both', expand=True, padx=16, pady=14)
+    capability = tk.Frame(
+        hero_inner, bg=COLORS['bg_3'],
+        highlightbackground=COLORS['border_2'], highlightthickness=1)
+    capability.pack(fill='x', pady=(18, 0))
+    capabilities = (
+        ('3', _('IMAGE FORMATS'), COLORS['accent_hi']),
+        ('1', _('BATCH QUEUE'), COLORS['teal_hi']),
+        ('PS5', _('TOOLKIT'), COLORS['purple_hi']),
+    )
+    for index, (value, caption, color) in enumerate(capabilities):
+        cell = tk.Frame(capability, bg=COLORS['bg_3'])
+        cell.pack(side='left', fill='both', expand=True,
+                  padx=(16 if index == 0 else 8, 16), pady=10)
+        tk.Label(
+            cell, text=value, font=(FONTS['mono'][0], 12, 'bold'),
+            bg=COLORS['bg_3'], fg=color, width=5, anchor='w'
+        ).pack(side='left')
+        tk.Label(
+            cell, text=caption, font=FONTS['eyebrow'],
+            bg=COLORS['bg_3'], fg=COLORS['fg_4'], anchor='w'
+        ).pack(side='left')
 
-        trow = tk.Frame(inner, bg=COLORS['bg_3'])
-        trow.pack(fill='x')
-        tk.Label(trow, text=icon, font=(FONTS['h2'][0], 18),
-                 bg=COLORS['bg_3'], fg=COLORS['teal']
-                 ).pack(side='left', padx=(0, 10))
-        tk.Label(trow, text=title, font=(FONTS['h3'][0], 13, 'bold'),
-                 bg=COLORS['bg_3'], fg=COLORS['fg_0'], anchor='w'
-                 ).pack(side='left')
+    def _section_header(title, subtitle):
+        row = tk.Frame(content, bg=COLORS['bg_1'])
+        row.pack(fill='x', pady=(24, 10))
+        tk.Label(
+            row, text=title, font=FONTS['h2'],
+            bg=COLORS['bg_1'], fg=COLORS['fg_0'], anchor='w'
+        ).pack(anchor='w')
+        tk.Label(
+            row, text=subtitle, font=FONTS['meta'],
+            bg=COLORS['bg_1'], fg=COLORS['fg_4'], anchor='w'
+        ).pack(anchor='w', pady=(2, 0))
 
-        tk.Label(inner, text=desc, font=FONTS['meta'],
-                 bg=COLORS['bg_3'], fg=COLORS['fg_4'], anchor='w',
-                 justify='left', wraplength=240
-                 ).pack(fill='x', pady=(8, 12))
+    def _action_card(parent_widget, key, icon, eyebrow, title, desc,
+                     accent='accent', primary=False):
+        card_bg = COLORS['bg_2'] if primary else COLORS['bg_3']
+        border = COLORS[accent] if primary else COLORS['border_3']
+        card = tk.Frame(
+            parent_widget, bg=card_bg,
+            highlightbackground=border, highlightthickness=1)
 
-        make_themed_button(inner, _('Open'),
-                           command=lambda k=key: _go(k), kind='primary',
-                           font_size=9, padx=14, pady=6
-                           ).pack(anchor='w')
+        inner = tk.Frame(card, bg=card_bg)
+        inner.pack(fill='both', expand=True, padx=20, pady=18)
 
-    for i, (key, icon, title, desc) in enumerate(cards):
-        _make_card(i, key, icon, title, desc)
+        top = tk.Frame(inner, bg=card_bg)
+        top.pack(fill='x')
+        icon_tile = tk.Frame(
+            top, bg=COLORS['accent_08'], width=44, height=44,
+            highlightbackground=COLORS['accent_15'], highlightthickness=1)
+        icon_tile.pack(side='left')
+        icon_tile.pack_propagate(False)
+        tk.Label(
+            icon_tile, text=icon, font=(FONTS['body'][0], 18, 'bold'),
+            bg=COLORS['accent_08'], fg=COLORS[accent]
+        ).pack(expand=True)
+
+        title_col = tk.Frame(top, bg=card_bg)
+        title_col.pack(side='left', fill='x', expand=True, padx=(12, 0))
+        tk.Label(
+            title_col, text=eyebrow.upper(), font=FONTS['eyebrow'],
+            bg=card_bg, fg=COLORS[accent], anchor='w'
+        ).pack(fill='x')
+        tk.Label(
+            title_col, text=title,
+            font=(FONTS['h3'][0], 13, 'bold'),
+            bg=card_bg, fg=COLORS['fg_0'], anchor='w'
+        ).pack(fill='x', pady=(2, 0))
+
+        description = tk.Label(
+            inner, text=desc, font=FONTS['body'],
+            bg=card_bg, fg=COLORS['fg_3'], anchor='w',
+            justify='left', wraplength=220)
+        description.pack(fill='x', pady=(14, 18))
+        card.bind(
+            '<Configure>',
+            lambda event, label=description: label.configure(
+                wraplength=max(150, event.width - 44)),
+            add='+')
+
+        make_themed_button(
+            inner, _('Open'), command=lambda route=key: _go(route),
+            kind='primary' if primary else 'ghost',
+            font_size=9, padx=16, pady=7
+        ).pack(anchor='w')
+        return card
+
+    _section_header(
+        _('Core workflows'),
+        _('Start with a game folder or work with an existing image.'))
+
+    workflow_grid = tk.Frame(content, bg=COLORS['bg_1'])
+    workflow_grid.pack(fill='x')
+    workflow_grid.grid_columnconfigure(0, weight=3, uniform='workflow')
+    workflow_grid.grid_columnconfigure(1, weight=2, uniform='workflow')
+
+    build_card = _action_card(
+        workflow_grid, 'unibuild', '+', _('PRIMARY WORKFLOW'),
+        _('Build Image'), _('Create a new image from a game folder.'),
+        accent='accent', primary=True)
+    build_card.grid(
+        row=0, column=0, rowspan=2, sticky='nsew', padx=(0, 12))
+
+    extract_card = _action_card(
+        workflow_grid, 'extract', '\u2191', _('EXISTING IMAGE'),
+        _('Extract Image'), _('Unpack an image back into files and folders.'),
+        accent='teal')
+    extract_card.grid(row=0, column=1, sticky='nsew', pady=(0, 12))
+
+    convert_card = _action_card(
+        workflow_grid, 'convert', '\u21c4', _('FORMAT TOOLS'),
+        _('Convert Image'),
+        _('Change an existing image between supported formats.'),
+        accent='purple')
+    convert_card.grid(row=1, column=1, sticky='nsew')
+
+    _section_header(
+        _('Workspace'),
+        _('Manage local content, console tools, and support resources.'))
+
+    workspace_grid = tk.Frame(content, bg=COLORS['bg_1'])
+    workspace_grid.pack(fill='x')
+    for column in range(3):
+        workspace_grid.grid_columnconfigure(
+            column, weight=1, uniform='workspace')
+
+    workspace_cards = (
+        ('library', '\u25a6', _('COLLECTION'), _('Library'),
+         _('Browse and manage your local game images.'), 'teal'),
+        ('ps5', '\u25ce', _('CONSOLE'), _('PS5 Tools'),
+         _('Connect, transfer, inspect logs, and manage tools.'), 'accent'),
+        ('report', '?', _('SUPPORT'), _('Report Issue'),
+         _('Create a diagnostic report or get help.'), 'purple'),
+    )
+    workspace_widgets = []
+    for column, card_data in enumerate(workspace_cards):
+        card = _action_card(workspace_grid, *card_data)
+        workspace_widgets.append(card)
+        card.grid(
+            row=0, column=column, sticky='nsew',
+            padx=(0 if column == 0 else 12, 0))
+
+    layout_state = {'compact': None}
+
+    def _responsive_layout(event):
+        compact = event.width < 780
+        if layout_state['compact'] == compact:
+            return
+        layout_state['compact'] = compact
+
+        for card in (build_card, extract_card, convert_card):
+            card.grid_forget()
+        if compact:
+            workflow_grid.grid_columnconfigure(0, weight=1, uniform='')
+            workflow_grid.grid_columnconfigure(1, weight=0, uniform='')
+            build_card.grid(row=0, column=0, sticky='nsew')
+            extract_card.grid(
+                row=1, column=0, sticky='nsew', pady=(12, 0))
+            convert_card.grid(
+                row=2, column=0, sticky='nsew', pady=(12, 0))
+        else:
+            workflow_grid.grid_columnconfigure(
+                0, weight=3, uniform='workflow')
+            workflow_grid.grid_columnconfigure(
+                1, weight=2, uniform='workflow')
+            build_card.grid(
+                row=0, column=0, rowspan=2, sticky='nsew',
+                padx=(0, 12))
+            extract_card.grid(
+                row=0, column=1, sticky='nsew', pady=(0, 12))
+            convert_card.grid(row=1, column=1, sticky='nsew')
+
+        for card in workspace_widgets:
+            card.grid_forget()
+        if compact:
+            workspace_grid.grid_columnconfigure(0, weight=1, uniform='')
+            workspace_grid.grid_columnconfigure(1, weight=0, uniform='')
+            workspace_grid.grid_columnconfigure(2, weight=0, uniform='')
+            for row, card in enumerate(workspace_widgets):
+                card.grid(
+                    row=row, column=0, sticky='nsew',
+                    pady=(0 if row == 0 else 12, 0))
+        else:
+            for column in range(3):
+                workspace_grid.grid_columnconfigure(
+                    column, weight=1, uniform='workspace')
+            for column, card in enumerate(workspace_widgets):
+                card.grid(
+                    row=0, column=column, sticky='nsew',
+                    padx=(0 if column == 0 else 12, 0))
+
+    page_canvas.bind('<Configure>', _responsive_layout, add='+')


### PR DESCRIPTION
## Summary

This PR modernizes the Tkinter desktop interface with a more visible dark technical-dashboard design while preserving existing application behavior.

## Changes

* Redesigned the Home screen as a responsive control-center dashboard
* Improved the application header, sidebar hierarchy, status bar, and output log
* Centralized the graphite color palette, accent colors, spacing, typography, and focus styles
* Standardized shared cards, panels, buttons, fields, drop zones, badges, and empty states
* Improved compact-width behavior so dashboard cards reflow more cleanly
* Improved keyboard focus visibility and readability across shared UI components

## Scope

This is a UI/UX-only change.

No changes were made to:

* PS5 workflows
* image building or conversion
* mounting or dismounting
* FTP behavior
* payload, exploit, or jailbreak behavior
* file-operation behavior
* command-execution behavior
* deployment logic

Existing callbacks, navigation routes, and workflow behavior are preserved.

## Validation

The following checks passed:

```powershell
python -m compileall -q exfat_builder.py tkinter_theme.py ui
python -c "import tkinter_theme as t; print(t.tokens_selftest())"
git diff --check
```

Additional validation:

* Shared-widget Tkinter construction smoke test passed
* Desktop and compact-width visual render checks passed
* Diff reviewed for accidental non-UI changes

## Manual Testing Checklist

* Launch the app with `python exfat_builder.py`
* Inspect the header, Home dashboard, sidebar, status bar, and output log
* Resize the window and confirm Home cards stack without clipping
* Test expanded and collapsed sidebar states
* Navigate through every sidebar destination
* Verify Build, Extract, Convert, Library, PS5 Tools, and Report Issue Home actions
* Check fields, Browse buttons, drop zones, tabs, queues, logs, empty states, and badges
* Verify keyboard focus with `Tab`, `Enter`, and `Space`
* Confirm warning and destructive actions remain visually distinct
* Expand, copy, clear, and collapse the output log
* Run representative existing workflows and confirm behavior is unchanged
